### PR TITLE
[BACKEND][FEAT] 라이브 스트리밍 실시간 인원 집계 기능구현

### DIFF
--- a/backend/api/src/main/java/com/youtube/api/CloneApplication.java
+++ b/backend/api/src/main/java/com/youtube/api/CloneApplication.java
@@ -2,7 +2,9 @@ package com.youtube.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication(
 		scanBasePackages = {
 				"com.youtube",

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/config/LiveStreamingViewerCountBroadcaster.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/config/LiveStreamingViewerCountBroadcaster.java
@@ -1,0 +1,73 @@
+package com.youtube.live.interaction.config;
+
+import com.youtube.live.interaction.livestreaming.domain.LiveStreamingViewerManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+/**
+ * 라이브 스트리밍 실시간 시청자 수 관리
+ *
+ * WebSocket 세션의 구독/연결해제 이벤트를 리스닝
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LiveStreamingViewerCountBroadcaster {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final LiveStreamingViewerManager liveStreamingViewerManager;
+
+    /**
+     * 클라이언트가 특정 토픽을 구독할 때 호출
+     */
+    @EventListener
+    public void handleSubscribe(final SessionSubscribeEvent event) {
+        final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        final String destination = accessor.getDestination();
+        final String simpSessionId = accessor.getSessionId();
+
+        if (destination != null && destination.matches("/topic/room/\\d+")) {
+            liveStreamingViewerManager.addViewer(extractRoomId(destination), simpSessionId);
+        }
+    }
+
+    /**
+     * 클라이언트 연결이 끊어질 때 호출
+     *
+     * 정상 종료(DISCONNECT)와 비정상 종료(네트워크 끊김 등) 모두 처리됨
+     */
+    @EventListener
+    public void handleDisconnect(final SessionDisconnectEvent event) {
+        liveStreamingViewerManager.removeViewer(event.getSessionId());
+    }
+
+    @Scheduled(fixedRate = 5000)
+    public void broadcastViewerCounts() {
+        liveStreamingViewerManager.getActiveRoomIds().forEach(roomId -> {
+            final int count = liveStreamingViewerManager.getViewerCount(roomId);
+
+            messagingTemplate.convertAndSend(
+                    "/topic/room/" + roomId + "/count",
+                    count
+            );
+        });
+    }
+
+    /**
+     * destination에서 roomId를 추출
+     *
+     * @param destination 예: "/topic/room/123"
+     * @return roomId 예: 123
+     */
+    private Long extractRoomId(final String destination) {
+        final String[] parts = destination.split("/");
+        return Long.parseLong(parts[parts.length - 1]);
+    }
+}

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/domain/LiveStreamingViewerManager.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/domain/LiveStreamingViewerManager.java
@@ -1,0 +1,70 @@
+package com.youtube.live.interaction.livestreaming.domain;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Slf4j
+public class LiveStreamingViewerManager {
+
+    /**
+     * 방별 시청자 세션 목록
+     * Key: roomId, Value: 해당 방을 구독 중인 simpSessionId 집합
+     *
+     * 시청자 수 계산
+     */
+    private final ConcurrentHashMap<Long, Set<String>> roomViewers = new ConcurrentHashMap<>();
+
+    /**
+     * 세션별 구독 중인 방
+     * Key: simpSessionId, Value: 구독 중인 roomId
+     *
+     * 연결 해제 시 어떤 방의 카운트를 감소시켜야 하는지 빠르게 찾기 위해 사용
+     */
+    private final ConcurrentHashMap<String, Long> sessionRoom = new ConcurrentHashMap<>();
+
+    public void addViewer(final Long roomId, final String simpSessionId) {
+        sessionRoom.compute(simpSessionId, (sid, prevRoomId) -> {
+            // 1) 이전 방에서 제거 (다르면)
+            if (prevRoomId != null && !prevRoomId.equals(roomId)) {
+                roomViewers.computeIfPresent(prevRoomId, (k, viewers) -> {
+                    viewers.remove(simpSessionId);
+                    return viewers.isEmpty() ? null : viewers;
+                });
+            }
+            // 2) 새 방에 추가
+            roomViewers.compute(roomId, (k, viewers) -> {
+                if (viewers == null) viewers = ConcurrentHashMap.newKeySet();
+                viewers.add(simpSessionId);
+                return viewers;
+            });
+            // 3) 매핑 최신화
+            return roomId;
+        });
+    }
+
+    public void removeViewer(final String simpSessionId) {
+        sessionRoom.computeIfPresent(simpSessionId, (sid, roomId) -> {
+            // 방의 viewer 목록에서도 세션 제거
+            roomViewers.computeIfPresent(roomId, (k, viewers) -> {
+                viewers.remove(simpSessionId);
+                // 방에 시청자가 더 이상 없으면 맵에서 정리
+                return viewers.isEmpty() ? null : viewers;
+            });
+            // sessionRoom에서 제거 (null 반환)
+            return null;
+        });
+    }
+
+    public int getViewerCount(final Long roomId) {
+        return roomViewers.getOrDefault(roomId, Collections.emptySet()).size();
+    }
+
+    public Set<Long> getActiveRoomIds() {
+        return Collections.unmodifiableSet(roomViewers.keySet());
+    }
+}

--- a/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/config/LiveStreamingViewerCountBroadcasterTest.java
+++ b/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/config/LiveStreamingViewerCountBroadcasterTest.java
@@ -1,0 +1,83 @@
+package com.youtube.live.interaction.config;
+
+import com.youtube.api.testfixtures.support.TestAuthSupport;
+import com.youtube.core.channel.domain.Channel;
+import com.youtube.core.testfixtures.builder.ChannelBuilder;
+import com.youtube.core.testfixtures.builder.UserBuilder;
+import com.youtube.live.interaction.builder.LiveStreamingBuilder;
+import com.youtube.live.interaction.livestreaming.domain.LiveStreaming;
+import com.youtube.live.interaction.support.TestStompSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static com.youtube.live.interaction.config.WebSocketConfig.Destinations.getRoomTopic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class LiveStreamingViewerCountBroadcasterTest extends WebSocketStompTest {
+
+    @Autowired
+    private LiveStreamingViewerCountBroadcaster sut;
+
+    @Test
+    @DisplayName("클라이언트 구독 및 해제 시 시청자 수 변경 이벤트가 정상 동작한다")
+    void subscribeAndUnsubscribeEventsWorkCorrectly() throws ExecutionException, InterruptedException, TimeoutException {
+        // given
+        final LiveStreaming liveStreaming = createLiveStreaming("user1@example.com", "유저1", "password1!");
+
+        final String jsessionId1 = TestAuthSupport.login("user1@example.com", "password1!");
+        final TestStompSession<Integer> session1 = TestStompSession.connect(wsUrl, jsessionId1);
+
+        TestAuthSupport.signUp("user2@example.com", "유저2", "password2!");
+        final String jsessionId2 = TestAuthSupport.login("user2@example.com", "password2!");
+        final TestStompSession<Integer> session2 = TestStompSession.connect(wsUrl, jsessionId2);
+
+        final String countTopic = "/topic/room/" + liveStreaming.getId() + "/count";
+        session1.subscribe(countTopic, Integer.class);
+
+        // when - 두 클라이언트가 방 구독
+        session1.subscribe(getRoomTopic(liveStreaming.getId()), Integer.class);
+        session2.subscribe(getRoomTopic(liveStreaming.getId()), Integer.class);
+
+        sut.broadcastViewerCounts();
+
+        // then - 시청자 수 2가 브로드캐스트됨
+        await().atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> {
+                    final List<Integer> counts = session1.getReceivedMessages(countTopic);
+                    assertThat(counts).hasSize(1);
+                    assertThat(counts.getFirst()).isEqualTo(2);
+                });
+
+        // when - 한 클라이언트 연결 해제
+        session2.disconnect();
+        // WebSocketStompTest의 설정에서 스케쥴러 비활성화해서 브로드캐스트를 임의로 실행해야함.
+        sut.broadcastViewerCounts();
+
+        // then - 연결 해제가 완전히 처리되고 시청자 수 1로 감소
+        await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    final List<Integer> counts = session1.getReceivedMessages(countTopic);
+                    assertThat(counts.size()).isGreaterThan(1);
+                    assertThat(counts.get(counts.size() - 1)).isEqualTo(1);
+                });
+
+        session1.disconnect();
+    }
+
+    private LiveStreaming createLiveStreaming(final String email, final String username, final String password) {
+        final Long userId = TestAuthSupport.signUp(email, username, password).as(Long.class);
+        final Channel channel = testSupport.save(
+                ChannelBuilder.Channel().withUser(UserBuilder.User().withId(userId).build()).build()
+        );
+        return testSupport.save(
+                LiveStreamingBuilder.LiveStreaming().withChannel(channel).build()
+        );
+    }
+}

--- a/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/config/WebSocketStompTest.java
+++ b/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/config/WebSocketStompTest.java
@@ -13,7 +13,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(
         classes = com.youtube.live.interaction.InteractionTestApplication.class,
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"spring.task.scheduling.enabled=false"}
 )
 @ActiveProfiles("websocket-test")
 public abstract class WebSocketStompTest extends TestContainer {

--- a/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/livestreaming/domain/LiveStreamingViewerManagerTest.java
+++ b/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/livestreaming/domain/LiveStreamingViewerManagerTest.java
@@ -1,0 +1,189 @@
+package com.youtube.live.interaction.livestreaming.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LiveStreamingViewerManagerTest {
+
+    private LiveStreamingViewerManager sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new LiveStreamingViewerManager();
+    }
+
+    @Test
+    @DisplayName("동일한 세션으로 중복 추가하면 시청자 수는 1로 유지된다")
+    void addingSameSessionTwiceKeepsCountAsOne() {
+        // given
+        final Long roomId = 1L;
+        final String simpSessionId = "session-1";
+
+        // when
+        sut.addViewer(roomId, simpSessionId);
+        sut.addViewer(roomId, simpSessionId);
+
+        // then
+        assertThat(sut.getViewerCount(roomId)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("시청자가 없는 방의 시청자 수는 0이다")
+    void emptyRoomHasZeroViewers() {
+        // given
+        final Long roomId = 1L;
+
+        // when
+        final int count = sut.getViewerCount(roomId);
+
+        // then
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("동시에 시청자 추가와 제거가 발생해도 정확한 시청자 수를 유지한다")
+    void addingAndRemovingViewersAtSameTimeKeepsAccurateCount() throws InterruptedException {
+        // given
+        final Long roomId = 1L;
+        final int threadCount = 20;
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount * 2);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int sessionNumber = i;
+            executorService.submit(() -> {
+                try {
+                    sut.addViewer(roomId, "session-" + sessionNumber);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        for (int i = 0; i < threadCount / 2; i++) {
+            final int sessionNumber = i;
+            executorService.submit(() -> {
+                try {
+                    sut.removeViewer("session-" + sessionNumber);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        // then
+        assertThat(sut.getViewerCount(roomId)).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("여러 방에 동시에 시청자가 추가되어도 각 방의 시청자 수를 정확히 유지한다")
+    void addingViewersToMultipleRoomsAtSameTimeKeepsAccurateCount() throws InterruptedException {
+        // given
+        final int roomCount = 10;
+        final int viewersPerRoom = 50;
+        final int totalThreads = roomCount * viewersPerRoom;
+        final ExecutorService executorService = Executors.newFixedThreadPool(totalThreads);
+        final CountDownLatch latch = new CountDownLatch(totalThreads);
+
+        // when
+        for (int roomId = 1; roomId <= roomCount; roomId++) {
+            final long finalRoomId = roomId;
+            for (int viewerIndex = 0; viewerIndex < viewersPerRoom; viewerIndex++) {
+                final int finalViewerIndex = viewerIndex;
+                executorService.submit(() -> {
+                    try {
+                        sut.addViewer(finalRoomId, "session-room" + finalRoomId + "-viewer" + finalViewerIndex);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        // then
+        for (int roomId = 1; roomId <= roomCount; roomId++) {
+            assertThat(sut.getViewerCount((long) roomId)).isEqualTo(viewersPerRoom);
+        }
+        assertThat(sut.getActiveRoomIds()).hasSize(roomCount);
+    }
+
+
+    @Test
+    @DisplayName("마지막 시청자가 나가는 동시에 새 시청자가 입장하면 새 시청자가 유실되지 않는다")
+    void lastViewerLeavingWhileNewViewerJoiningDoesNotLoseData() throws InterruptedException {
+        // given
+        final Long roomId = 1L;
+        final int iterations = 100;
+        int dataLossCount = 0;
+
+        // when: 반복적으로 race condition 발생 시도
+        for (int i = 0; i < iterations; i++) {
+            final String existingSession = "session-existing-" + i;
+            final String newSession = "session-new-" + i;
+
+            // 기존 시청자 1명 추가
+            sut.addViewer(roomId, existingSession);
+
+            final ExecutorService executorService = Executors.newFixedThreadPool(2);
+            final CountDownLatch startLatch = new CountDownLatch(1);
+            final CountDownLatch endLatch = new CountDownLatch(2);
+
+            // 스레드1: 마지막 시청자 제거
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    sut.removeViewer(existingSession);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+
+            // 스레드2: 새 시청자 추가
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    sut.addViewer(roomId, newSession);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+
+            startLatch.countDown(); // 동시 시작
+            endLatch.await(1, TimeUnit.SECONDS);
+            executorService.shutdown();
+
+            // 검증: 새 시청자가 추가되었어야 함
+            final int viewerCount = sut.getViewerCount(roomId);
+            if (viewerCount == 0) {
+                dataLossCount++;
+            }
+
+            // 다음 iteration을 위한 정리
+            sut.removeViewer(newSession);
+        }
+
+        // then: 데이터 손실이 발생하지 않아야 함
+        assertThat(dataLossCount)
+                .as("데이터 손실이 %d번 발생했습니다", dataLossCount)
+                .isZero();
+    }
+
+}


### PR DESCRIPTION
- 라이브 스트리밍 실시간 인원 집계 기능구현
  - 5초 주기로 시청자 수를 브로드 캐스트 (현 유튜브와 동일한 방식)
  - 새로운 방 구독 시 이전 방에서 세션 자동 제거
  - 세션 종료 시 구독 중이던 모든 방에서 세션 자동 제거
  - 시청자가 0명이 된 방은 메모리에서 자동 제거
  - ConcurrentHashMap으로 동시성 처리 (단일 서버를 기준으로 구현)