### PR TITLE
[Backend][Feat] 웹소켓 인증 체계 개선 및 비회원 접속 지원

### DIFF
--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/config/WebSocketConfig.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/config/WebSocketConfig.java
@@ -1,12 +1,17 @@
 package com.youtube.live.interaction.config;
 
+import com.youtube.live.interaction.websocket.auth.AuthUserArgumentResolver;
+import com.youtube.live.interaction.websocket.auth.WebSocketAuthInterceptor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+
+import java.util.List;
 
 /**
  * WebSocket 설정 클래스
@@ -74,6 +79,17 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(new WebSocketAuthInterceptor());
+    }
+
+    /**
+     * 커스텀 ArgumentResolver를 등록합니다.
+     *
+     * AuthUserArgumentResolver를 등록하여 @AuthUser 어노테이션이 붙은 파라미터에
+     * 인증된 사용자 정보를 주입합니다.
+     */
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new AuthUserArgumentResolver());
     }
 
     /**

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/controller/WebSocketChatController.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/controller/WebSocketChatController.java
@@ -1,6 +1,7 @@
 package com.youtube.live.interaction.livestreaming.controller;
 
-import com.youtube.live.interaction.config.StompPrincipal;
+import com.youtube.live.interaction.websocket.auth.AuthUser;
+import com.youtube.live.interaction.websocket.auth.LoginUser;
 import com.youtube.live.interaction.livestreaming.controller.dto.ChatMessageRequest;
 import com.youtube.live.interaction.livestreaming.controller.dto.ChatMessageResponse;
 import com.youtube.live.interaction.livestreaming.controller.dto.ErrorResponse;
@@ -16,7 +17,6 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
-import java.security.Principal;
 import java.time.LocalDateTime;
 
 @Controller
@@ -30,10 +30,10 @@ public class WebSocketChatController {
     @SendTo("/topic/room/{roomId}")
     public ChatMessageResponse sendMessage(@DestinationVariable final Long roomId,
                                            @Payload final ChatMessageRequest chatMessageRequest,
-                                           final Principal principal) {
-        final StompPrincipal stompPrincipal = (StompPrincipal) principal;
-        final Long userId = stompPrincipal.getUserId();
-        final String username = stompPrincipal.getUsername();
+                                           @AuthUser LoginUser loginUser
+    ) {
+        final Long userId = loginUser.getUserId();
+        final String username = loginUser.getUsername();
 
         final LiveStreamingChatInfo savedChatInfo = liveStreamingChatService.sendMessage(
                 roomId,

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/AuthUser.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/AuthUser.java
@@ -1,0 +1,22 @@
+package com.youtube.live.interaction.websocket.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * WebSocket 메시지 핸들러에서 인증된 사용자 정보를 주입받기 위한 어노테이션
+ *
+ * required = true: 인증 필수
+ * required = false: 인증 선택 (비회원 접근 시 null 반환)
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {
+    /**
+     * 인증 필수 여부
+     * @return true면 인증 필수, false면 선택적 인증
+     */
+    boolean required() default true;
+}

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/AuthUserArgumentResolver.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/AuthUserArgumentResolver.java
@@ -1,0 +1,58 @@
+package com.youtube.live.interaction.websocket.auth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+
+import java.security.Principal;
+
+/**
+ * @AuthUser 어노테이션이 붙은 파라미터에 인증된 사용자 정보를 주입하는 Resolver
+ */
+@Slf4j
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class)
+                && parameter.getParameterType().equals(LoginUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            final MethodParameter parameter,
+            final Message<?> message
+    ) throws Exception {
+        final StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(
+                message,
+                StompHeaderAccessor.class
+        );
+
+        final Principal principal = accessor.getUser();
+
+        if (principal instanceof UnauthenticatedPrincipal) {
+            return handleUnAuthUser(parameter);
+        }
+
+        if (principal instanceof AuthenticatedPrincipal) {
+            final AuthenticatedPrincipal authenticatedPrincipal = (AuthenticatedPrincipal) principal;
+            return new LoginUser(authenticatedPrincipal.getUserId(), authenticatedPrincipal.getUsername());
+        }
+
+        log.error("예상하지 못한 Principal 타입 - type: {}", principal != null ? principal.getClass().getName() : "null");
+        throw new IllegalStateException("인증 정보 처리 오류");
+    }
+
+    private Object handleUnAuthUser(final MethodParameter parameter) {
+        final AuthUser authUser = parameter.getParameterAnnotation(AuthUser.class);
+        if (authUser != null && authUser.required()) {
+            log.warn("인증이 필요한 기능에 비회원이 접근했습니다");
+            throw new IllegalStateException("로그인이 필요한 기능입니다");
+        }
+
+        return null;
+    }
+}

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/AuthenticatedPrincipal.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/AuthenticatedPrincipal.java
@@ -1,16 +1,13 @@
-package com.youtube.live.interaction.config;
+package com.youtube.live.interaction.websocket.auth;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.security.Principal;
 
-/**
- * STOMP 메시지에서 사용자 정보를 담는 Principal 구현체
- */
 @Getter
 @AllArgsConstructor
-public class StompPrincipal implements Principal {
+public class AuthenticatedPrincipal implements Principal {
 
     private final Long userId;
     private final String username;

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/LoginUser.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/LoginUser.java
@@ -1,0 +1,12 @@
+package com.youtube.live.interaction.websocket.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginUser {
+
+    private final Long userId;
+    private final String username;
+}

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/UnauthenticatedPrincipal.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/UnauthenticatedPrincipal.java
@@ -1,0 +1,11 @@
+package com.youtube.live.interaction.websocket.auth;
+
+import java.security.Principal;
+
+public class UnauthenticatedPrincipal implements Principal {
+
+    @Override
+    public String getName() {
+        return "anonymous";
+    }
+}

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/WebSocketAuthInterceptor.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/auth/WebSocketAuthInterceptor.java
@@ -1,4 +1,4 @@
-package com.youtube.live.interaction.config;
+package com.youtube.live.interaction.websocket.auth;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -10,9 +10,8 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 
 /**
  * WebSocket 메시지의 인증을 처리하는 인터셉터
- *
- * STOMP CONNECT 메시지가 처리될 때 세션의 인증 정보를 검증하고
- * Principal 객체를 설정하여 컨트롤러에서 사용할 수 있도록 합니다.
+ * <p>
+ * STOMP CONNECT 메시지가 처리될 때 세션 속성의 인증 정보를 확인하여 적절한 Principal을 설정합니다.
  */
 @Slf4j
 public class WebSocketAuthInterceptor implements ChannelInterceptor {
@@ -25,13 +24,15 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
             final Long userId = (Long) accessor.getSessionAttributes().get("userId");
             final String username = (String) accessor.getSessionAttributes().get("username");
 
-            if (userId == null || username == null) {
-                log.warn("WebSocket 연결 인증 실패 - 세션 정보 없음");
-                throw new IllegalStateException("인증되지 않은 사용자입니다");
+            if (userId != null && username != null) {
+                accessor.setUser(new AuthenticatedPrincipal(userId, username));
+            } else if( userId == null && username == null){
+                accessor.setUser(new UnauthenticatedPrincipal());
+            } else {
+                log.error("WebSocket 연결 실패 - sessionId: {}, userId: {}, username 존재 여부: {}",
+                        accessor.getSessionId(), userId, username != null);
+                throw new IllegalStateException("인증 정보가 올바르지 않습니다");
             }
-
-            // Principal 설정으로 컨트롤러에서 사용 가능하도록 함
-            accessor.setUser(new StompPrincipal(userId, username));
         }
 
         return message;

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/event/LiveStreamingViewerCountBroadcaster.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/websocket/event/LiveStreamingViewerCountBroadcaster.java
@@ -1,4 +1,4 @@
-package com.youtube.live.interaction.config;
+package com.youtube.live.interaction.websocket.event;
 
 import com.youtube.live.interaction.livestreaming.domain.LiveStreamingViewerManager;
 import lombok.RequiredArgsConstructor;

--- a/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/config/LiveStreamingViewerCountBroadcasterTest.java
+++ b/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/config/LiveStreamingViewerCountBroadcasterTest.java
@@ -7,6 +7,7 @@ import com.youtube.core.testfixtures.builder.UserBuilder;
 import com.youtube.live.interaction.builder.LiveStreamingBuilder;
 import com.youtube.live.interaction.livestreaming.domain.LiveStreaming;
 import com.youtube.live.interaction.support.TestStompSession;
+import com.youtube.live.interaction.websocket.event.LiveStreamingViewerCountBroadcaster;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/livestreaming/controller/WebSocketChatControllerTest.java
+++ b/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/livestreaming/controller/WebSocketChatControllerTest.java
@@ -24,7 +24,6 @@ import static com.youtube.core.testfixtures.builder.ChannelBuilder.*;
 import static com.youtube.live.interaction.builder.LiveStreamingBuilder.*;
 import static com.youtube.live.interaction.config.WebSocketConfig.Destinations.getRoomTopic;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 @Slf4j
@@ -208,12 +207,14 @@ class WebSocketChatControllerTest extends WebSocketStompTest {
     }
 
     @Test
-    @DisplayName("세션 정보가 없으면 WebSocket 연결이 실패한다")
-    void connectWithoutSession() {
-        // given: 세션 정보 없이 WebSocket 연결 시도 (jsessionId를 null로 전달)
-        // when & then: 인터셉터에서 인증 실패로 연결이 타임아웃됨
-        assertThatThrownBy(() -> TestStompSession.connect(wsUrl, null))
-                .isInstanceOf(TimeoutException.class);
+    @DisplayName("인증되지 않은 사용자도 WebSocket 연결에 성공한다")
+    void connectWithoutSessionSucceeds() throws ExecutionException, InterruptedException, TimeoutException {
+        // given & when
+        final TestStompSession<ChatMessageResponse> testSession = TestStompSession.connect(wsUrl, null);
+        // then
+        assertThat(testSession).isNotNull();
+
+        testSession.disconnect();
     }
 
     @Test


### PR DESCRIPTION
- Principal 개선
  - StompPrincipal → AuthenticatedPrincipal (인증된 사용자)
  - UnauthenticatedPrincipal 추가 (비인증 사용자)
- 컨트롤러용 인증 어노테이션 추가
  - `@AuthUser` 어노테이션 추가
  - AuthUserArgumentResolver 구현
- 컨트롤러 리팩토링
  - Principal 직접 사용 → `@AuthUser LoginUser` 사용
- 비회원 접속 지원
  - WebSocketAuthInterceptor에서 인증/비인증 분기 처리
- 패키지 구조 개선