### PR TITLE
[Backend][Feat] 라이브 스트리 채팅에 접속 시 초기 데이터 30개 조회 기능구현

### DIFF
--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/controller/dto/InitialChatMessagesResponse.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/controller/dto/InitialChatMessagesResponse.java
@@ -1,0 +1,6 @@
+package com.youtube.live.interaction.livestreaming.controller.dto;
+
+import java.util.List;
+
+public record InitialChatMessagesResponse (List<ChatMessageResponse> messages) {
+}

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/domain/LiveStreamingChatReader.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/domain/LiveStreamingChatReader.java
@@ -1,0 +1,25 @@
+package com.youtube.live.interaction.livestreaming.domain;
+
+import com.youtube.live.interaction.livestreaming.controller.dto.ChatMessageResponse;
+import com.youtube.live.interaction.livestreaming.repository.LiveStreamingChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class LiveStreamingChatReader {
+
+    private final LiveStreamingChatRepository liveStreamingChatRepository;
+
+    public List<ChatMessageResponse> readRecentChats(
+            final Long liveStreamingId,
+            final int pageSize) {
+        return liveStreamingChatRepository.findByLiveStreamingIdOrderByCreatedDateDesc(
+                liveStreamingId,
+                PageRequest.of(0, pageSize)
+        );
+    }
+}

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/repository/LiveStreamingChatRepository.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/repository/LiveStreamingChatRepository.java
@@ -1,7 +1,24 @@
 package com.youtube.live.interaction.livestreaming.repository;
 
+import com.youtube.live.interaction.livestreaming.controller.dto.ChatMessageResponse;
 import com.youtube.live.interaction.livestreaming.domain.LiveStreamingChat;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface LiveStreamingChatRepository extends JpaRepository<LiveStreamingChat, java.lang.Long> {
+
+    @Query("SELECT new com.youtube.live.interaction.livestreaming.controller.dto.ChatMessageResponse(" +
+            "u.username, c.message, c.messageType, u.profileImageUrl, c.createdDate) " +
+            "FROM LiveStreamingChat c " +
+            "JOIN c.user u " +
+            "WHERE c.liveStreaming.id = :livestreamId " +
+            "ORDER BY c.createdDate DESC")
+    List<ChatMessageResponse> findByLiveStreamingIdOrderByCreatedDateDesc(
+            @Param("livestreamId") final Long livestreamId,
+            final Pageable pageable
+    );
 }

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/service/LiveStreamingChatQueryService.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/service/LiveStreamingChatQueryService.java
@@ -1,0 +1,24 @@
+package com.youtube.live.interaction.livestreaming.service;
+
+import com.youtube.live.interaction.livestreaming.controller.dto.ChatMessageResponse;
+import com.youtube.live.interaction.livestreaming.domain.LiveStreamingChatReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LiveStreamingChatQueryService {
+
+    private final LiveStreamingChatReader liveStreamingChatReader;
+
+    public List<ChatMessageResponse> getInitialMessages(final Long liveStreamingId) {
+        final List<ChatMessageResponse> recentChats = liveStreamingChatReader.readRecentChats(liveStreamingId, 30);
+        Collections.reverse(recentChats);
+        return recentChats;
+    }
+}

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/service/LiveStreamingChatService.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/service/LiveStreamingChatService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class LiveStreamingChatService {
@@ -18,12 +20,12 @@ public class LiveStreamingChatService {
 
     @Transactional
     public LiveStreamingChatInfo sendMessage(final Long liveStreamingId, final Long userId, final String message,
-                                             final ChatMessageType messageType) {
+                                             final ChatMessageType messageType, final LocalDateTime now) {
         final LiveStreaming liveStreaming = liveStreamingReader.readBy(liveStreamingId);
         final User user = userReader.readBy(userId);
 
         liveStreamingChatWriter.write(liveStreaming, user, message, messageType);
 
-        return LiveStreamingChatInfo.of(user, message, messageType);
+        return LiveStreamingChatInfo.of(user, message, messageType, now);
     }
 }

--- a/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/service/dto/LiveStreamingChatInfo.java
+++ b/backend/live-streaming/interaction/src/main/java/com/youtube/live/interaction/livestreaming/service/dto/LiveStreamingChatInfo.java
@@ -5,6 +5,8 @@ import com.youtube.live.interaction.livestreaming.domain.ChatMessageType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Data
 @AllArgsConstructor
 public class LiveStreamingChatInfo {
@@ -13,12 +15,14 @@ public class LiveStreamingChatInfo {
     private String message;
     private ChatMessageType chatMessageType;
     private String userProfileImageUrl;
+    private LocalDateTime timestamp;
 
     public static LiveStreamingChatInfo of(
             final User user,
             final String message,
-            final ChatMessageType chatMessageType)
+            final ChatMessageType chatMessageType,
+            final LocalDateTime timestamp)
     {
-        return new LiveStreamingChatInfo(user.getUsername(), message, chatMessageType, user.getProfileImageUrl());
+        return new LiveStreamingChatInfo(user.getUsername(), message, chatMessageType, user.getProfileImageUrl(), timestamp);
     }
 }

--- a/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/livestreaming/repository/LiveStreamingChatRepositoryTest.java
+++ b/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/livestreaming/repository/LiveStreamingChatRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.youtube.live.interaction.livestreaming.repository;
+
+import com.youtube.core.channel.domain.Channel;
+import com.youtube.core.user.domain.User;
+import com.youtube.live.interaction.config.IntegrationTest;
+import com.youtube.live.interaction.livestreaming.controller.dto.ChatMessageResponse;
+import com.youtube.live.interaction.livestreaming.domain.LiveStreaming;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static com.youtube.core.testfixtures.builder.ChannelBuilder.Channel;
+import static com.youtube.core.testfixtures.builder.UserBuilder.User;
+import static com.youtube.live.interaction.builder.LiveStreamingBuilder.LiveStreaming;
+import static com.youtube.live.interaction.builder.LiveStreamingChatBuilder.LiveStreamingChat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LiveStreamingChatRepositoryTest extends IntegrationTest {
+
+    @Autowired
+    private LiveStreamingChatRepository sut;
+
+    @Test
+    @DisplayName("createdDate가 내림차순으로 정렬된 채팅 메시지를 요청한 개수만큼 조회한다")
+    void findMessagesByLiveStreamingId_OrderedByCreatedDateDesc() {
+        // given
+        final User user = testSupport.save(User().build());
+        final Channel channel = testSupport.save(Channel().withUser(user).build());
+        final LiveStreaming liveStreaming = testSupport.save(LiveStreaming().withChannel(channel).build());
+
+        for (int i = 1; i <= 31; i++) {
+            testSupport.save(
+                    LiveStreamingChat()
+                            .withLiveStreaming(liveStreaming)
+                            .withUser(user)
+                            .withMessage("메시지 " + i)
+                            .build()
+            );
+        }
+
+        // when
+        final List<ChatMessageResponse> result = sut.findByLiveStreamingIdOrderByCreatedDateDesc(
+                liveStreaming.getId(),
+                PageRequest.of(0, 30)
+        );
+
+        // then
+        assertThat(result).hasSize(30);
+        assertThat(result.get(0).getMessage()).isEqualTo("메시지 31");
+        assertThat(result.get(29).getMessage()).isEqualTo("메시지 2");
+    }
+
+    @Test
+    @DisplayName("채팅 메시지가 30개 미만일 때 모든 메시지를 조회한다")
+    void findMessagesByLiveStreamingId_LessThan30Chats_ReturnsAll() {
+        // given
+        final User user = testSupport.save(User().build());
+        final Channel channel = testSupport.save(Channel().withUser(user).build());
+        final LiveStreaming liveStreaming = testSupport.save(LiveStreaming().withChannel(channel).build());
+
+        for (int i = 1; i <= 10; i++) {
+            testSupport.save(
+                    LiveStreamingChat()
+                            .withLiveStreaming(liveStreaming)
+                            .withUser(user)
+                            .withMessage("메시지 " + i)
+                            .build()
+            );
+        }
+
+        // when
+        final List<ChatMessageResponse> result = sut.findByLiveStreamingIdOrderByCreatedDateDesc(
+                liveStreaming.getId(),
+                PageRequest.of(0, 30)
+        );
+
+        // then
+        assertThat(result).hasSize(10);
+    }
+}

--- a/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/websocket/event/LiveStreamingViewerCountPublisherTest.java
+++ b/backend/live-streaming/interaction/src/test/java/com/youtube/live/interaction/websocket/event/LiveStreamingViewerCountPublisherTest.java
@@ -47,7 +47,7 @@ class LiveStreamingViewerCountPublisherTest extends WebSocketStompTest {
         sut.publishViewerCounts();
 
         // then - 스트리머는 카운트에서 제외되어 시청자 수 0
-        await().atMost(Duration.ofSeconds(5))
+        await().atMost(Duration.ofSeconds(10))
                 .untilAsserted(() -> {
                     final List<Integer> receivedMessages = streamerSession.getReceivedMessages(countTopic);
                     assertThat(receivedMessages).hasSize(1);
@@ -59,7 +59,7 @@ class LiveStreamingViewerCountPublisherTest extends WebSocketStompTest {
         sut.publishViewerCounts();
 
         // then - 시청자 수 1로 증가 (스트리머 제외, 시청자만 카운트)
-        await().atMost(Duration.ofSeconds(5))
+        await().atMost(Duration.ofSeconds(10))
                 .untilAsserted(() -> {
                     final List<Integer> counts = streamerSession.getReceivedMessages(countTopic);
                     assertThat(counts.size()).isGreaterThan(1);

--- a/backend/live-streaming/interaction/src/testFixtures/java/com/youtube/live/interaction/builder/LiveStreamingChatBuilder.java
+++ b/backend/live-streaming/interaction/src/testFixtures/java/com/youtube/live/interaction/builder/LiveStreamingChatBuilder.java
@@ -1,0 +1,36 @@
+package com.youtube.live.interaction.builder;
+
+import com.youtube.core.user.domain.User;
+import com.youtube.live.interaction.livestreaming.domain.ChatMessageType;
+import com.youtube.live.interaction.livestreaming.domain.LiveStreaming;
+import com.youtube.live.interaction.livestreaming.domain.LiveStreamingChat;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.With;
+
+@With
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LiveStreamingChatBuilder {
+
+    private Long id;
+    private LiveStreaming liveStreaming;
+    private User user;
+    private String message = "테스트 채팅 메시지";
+    private ChatMessageType messageType = ChatMessageType.CHAT;
+
+    public static LiveStreamingChatBuilder LiveStreamingChat() {
+        return new LiveStreamingChatBuilder();
+    }
+
+    public LiveStreamingChat build() {
+        return LiveStreamingChat.builder()
+                .id(this.id)
+                .liveStreaming(this.liveStreaming)
+                .user(this.user)
+                .message(this.message)
+                .messageType(this.messageType)
+                .build();
+    }
+}


### PR DESCRIPTION
- STOMP의 `@SubscribeMapping`을 사용해 초기 데이터 30개 로드
- offset 방식으로 구현