### PR TITLE
[Backend][Feat] 알림 생성 및 푸시 기능 구현

### DIFF
--- a/backend/api/src/main/java/com/youtube/api/notification/NotificationPushEventListener.java
+++ b/backend/api/src/main/java/com/youtube/api/notification/NotificationPushEventListener.java
@@ -2,41 +2,32 @@ package com.youtube.api.notification;
 
 import com.youtube.notification.domain.NotificationReader;
 import com.youtube.notification.event.NotificationCreatedEvent;
+import com.youtube.notification.service.WebPushPayloadConverter;
+import com.youtube.notification.service.WebPushService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class NotificationPushEventListener {
 
     private final NotificationSseManager notificationSseManager;
     private final NotificationReader notificationReader;
+    private final WebPushService webPushService;
+    private final WebPushPayloadConverter webPushPayloadConverter;
 
     @Async
     @EventListener
     public void onNotificationCreated(final NotificationCreatedEvent event) {
         final Long receiverId = event.receiverId();
 
-        try {
-            if (notificationSseManager.hasConnection(receiverId)) {
-                notificationSseManager.sendNotification(receiverId, event);
-                final long unreadCount = notificationReader.countUnreadBy(receiverId);
-                notificationSseManager.sendUnreadCount(receiverId, unreadCount);
-
-                log.info("알림 전송 성공 (SSE) - notificationId: {}, receiverId: {}, unreadCount: {}",
-                        event.notificationId(), receiverId, unreadCount);
-            } else {
-                // TODO: WebPush 전송 구현 예정
-                log.debug("SSE 연결 없음, WebPush 전송 예정 - notificationId: {}, receiverId: {}",
-                        event.notificationId(), receiverId);
-            }
-        } catch (Exception e) {
-            log.warn("알림 푸시 전송 실패 - notificationId: {}, receiverId: {}, error: {}",
-                    event.notificationId(), receiverId, e.getMessage(), e);
+        if (notificationSseManager.hasConnection(receiverId)) {
+            notificationSseManager.sendNotification(receiverId, event);
+            notificationSseManager.sendUnreadCount(receiverId, notificationReader.countUnreadBy(receiverId));
+        } else {
+            webPushService.sendNotification(receiverId, webPushPayloadConverter.toPayload(event));
         }
     }
 }

--- a/backend/api/src/main/java/com/youtube/api/notification/PushSubscriptionController.java
+++ b/backend/api/src/main/java/com/youtube/api/notification/PushSubscriptionController.java
@@ -1,0 +1,77 @@
+package com.youtube.api.notification;
+
+import com.youtube.notification.service.PushSubscriptionService;
+import com.youtube.notification.service.dto.PushSubscribeRequest;
+import com.youtube.notification.service.dto.PushUnsubscribeRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/push")
+public class PushSubscriptionController {
+
+    private final PushSubscriptionService pushSubscriptionService;
+    private static final String SESSION_USER_ID = "userId";
+
+    @PostMapping("/subscribe")
+    public ResponseEntity<Void> subscribe(
+            @RequestBody final PushSubscribeRequest request,
+            final HttpSession session
+    ) {
+        final Long userId = (Long) session.getAttribute(SESSION_USER_ID);
+        if (userId == null) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+
+        pushSubscriptionService.subscribe(userId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/unsubscribe")
+    public ResponseEntity<Void> unsubscribe(
+            @RequestBody final PushUnsubscribeRequest request,
+            final HttpSession session
+    ) {
+        final Long userId = (Long) session.getAttribute(SESSION_USER_ID);
+        if (userId == null) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+
+        pushSubscriptionService.unsubscribe(request.endpoint());
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/deactivate")
+    public ResponseEntity<Void> deactivateAllSubscriptions(
+            final HttpSession session
+    ) {
+        final Long userId = (Long) session.getAttribute(SESSION_USER_ID);
+        if (userId == null) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+
+        pushSubscriptionService.deactivateAllSubscriptions(userId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/reactivate")
+    public ResponseEntity<Void> reactivateSubscription(
+            @RequestBody final PushUnsubscribeRequest request,
+            final HttpSession session
+    ) {
+        final Long userId = (Long) session.getAttribute(SESSION_USER_ID);
+        if (userId == null) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+
+        pushSubscriptionService.reactivateSubscription(userId, request.endpoint());
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/api/src/test/java/com/youtube/api/notification/PushSubscriptionControllerTest.java
+++ b/backend/api/src/test/java/com/youtube/api/notification/PushSubscriptionControllerTest.java
@@ -1,0 +1,233 @@
+package com.youtube.api.notification;
+
+import com.youtube.api.config.RestAssuredTest;
+import com.youtube.api.testfixtures.support.TestAuthSupport;
+import com.youtube.core.user.domain.QUser;
+import com.youtube.core.user.domain.User;
+import com.youtube.notification.service.dto.PushSubscribeRequest;
+import com.youtube.notification.service.dto.PushUnsubscribeRequest;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static com.youtube.notification.testfixtures.builder.PushSubscriptionBuilder.PushSubscription;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PushSubscriptionControllerTest extends RestAssuredTest {
+
+    @Test
+    @DisplayName("로그인한 사용자가 푸시 알림을 구독하면 성공한다")
+    void subscribe_LoggedInUser_Success() {
+        // given
+        final Long userId = TestAuthSupport.signUp("user@example.com", "testuser", "password123").as(Long.class);
+        final String sessionCookie = TestAuthSupport.login("user@example.com", "password123");
+
+        final PushSubscribeRequest request = new PushSubscribeRequest(
+                "https://fcm.googleapis.com/fcm/send/test-endpoint",
+                new PushSubscribeRequest.Keys("p256dh-key", "auth-key"),
+                "Mozilla/5.0"
+        );
+
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .cookie("JSESSIONID", sessionCookie)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/push/subscribe")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 푸시 알림을 구독하려고 하면 오류가 발생한다")
+    void subscribe_NotLoggedIn_Error() {
+        // given
+        final PushSubscribeRequest request = new PushSubscribeRequest(
+                "https://fcm.googleapis.com/fcm/send/test-endpoint",
+                new PushSubscribeRequest.Keys("p256dh-key", "auth-key"),
+                "Mozilla/5.0"
+        );
+
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/push/subscribe")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 푸시 알림 구독을 해제하면 성공한다")
+    void unsubscribe_LoggedInUser_Success() {
+        // given
+        final Long userId = TestAuthSupport.signUp("user@example.com", "testuser", "password123").as(Long.class);
+        final String sessionCookie = TestAuthSupport.login("user@example.com", "password123");
+
+        final User user = findUserById(userId);
+        final String endpoint = "https://fcm.googleapis.com/fcm/send/unsubscribe-endpoint";
+        testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withEndpoint(endpoint)
+                        .build()
+        );
+
+        final PushUnsubscribeRequest request = new PushUnsubscribeRequest(endpoint);
+
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .cookie("JSESSIONID", sessionCookie)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .delete("/api/v1/push/unsubscribe")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 푸시 알림 구독을 해제하려고 하면 오류가 발생한다")
+    void unsubscribe_NotLoggedIn_Error() {
+        // given
+        final PushUnsubscribeRequest request = new PushUnsubscribeRequest(
+                "https://fcm.googleapis.com/fcm/send/test-endpoint"
+        );
+
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .delete("/api/v1/push/unsubscribe")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 모든 푸시 알림 구독을 비활성화하면 성공한다")
+    void deactivateAllSubscriptions_LoggedInUser_Success() {
+        // given
+        final Long userId = TestAuthSupport.signUp("user@example.com", "testuser", "password123").as(Long.class);
+        final String sessionCookie = TestAuthSupport.login("user@example.com", "password123");
+
+        final User user = findUserById(userId);
+        testSupport.saveAll(
+                PushSubscription().withUser(user).withEndpoint("endpoint-1").withActive(true).build(),
+                PushSubscription().withUser(user).withEndpoint("endpoint-2").withActive(true).build(),
+                PushSubscription().withUser(user).withEndpoint("endpoint-3").withActive(true).build()
+        );
+
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .cookie("JSESSIONID", sessionCookie)
+                .when()
+                .post("/api/v1/push/deactivate")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 모든 푸시 알림 구독을 비활성화하려고 하면 오류가 발생한다")
+    void deactivateAllSubscriptions_NotLoggedIn_Error() {
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .when()
+                .post("/api/v1/push/deactivate")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 특정 푸시 알림 구독을 재활성화하면 성공한다")
+    void reactivateSubscription_LoggedInUser_Success() {
+        // given
+        final Long userId = TestAuthSupport.signUp("user@example.com", "testuser", "password123").as(Long.class);
+        final String sessionCookie = TestAuthSupport.login("user@example.com", "password123");
+
+        final User user = findUserById(userId);
+        final String endpoint = "https://fcm.googleapis.com/fcm/send/reactivate-endpoint";
+        testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withEndpoint(endpoint)
+                        .withActive(false)
+                        .build()
+        );
+
+        final PushUnsubscribeRequest request = new PushUnsubscribeRequest(endpoint);
+
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .cookie("JSESSIONID", sessionCookie)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/push/reactivate")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 푸시 알림 구독을 재활성화하려고 하면 오류가 발생한다")
+    void reactivateSubscription_NotLoggedIn_Error() {
+        // given
+        final PushUnsubscribeRequest request = new PushUnsubscribeRequest(
+                "https://fcm.googleapis.com/fcm/send/test-endpoint"
+        );
+
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/push/reactivate")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    private User findUserById(final Long userId) {
+        return testSupport.jpaQueryFactory
+                .selectFrom(QUser.user)
+                .where(QUser.user.id.eq(userId))
+                .fetchOne();
+    }
+}

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -29,6 +29,7 @@ val restAssuredVersion: String by project
 val testContainerVersion: String by project
 val testContainerMySqlVersion: String by project
 val querydslVersion: String by project
+val awaitilityVersion: String by project
 subprojects {
 	plugins.apply("java")
 	plugins.apply("org.springframework.boot")
@@ -39,6 +40,8 @@ subprojects {
 		compileOnly("org.projectlombok:lombok:${lombokVersion}")
 		annotationProcessor("org.projectlombok:lombok:${lombokVersion}")
 
+		implementation("com.fasterxml.jackson.core:jackson-databind")
+
 		testImplementation("org.springframework.boot:spring-boot-starter-test")
 		testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
 		testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -47,6 +50,7 @@ subprojects {
 		testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
 		testImplementation("com.querydsl:querydsl-jpa:${querydslVersion}:jakarta")
 		testImplementation("com.querydsl:querydsl-apt:${querydslVersion}:jakarta")
+		testImplementation("org.awaitility:awaitility:${awaitilityVersion}")
 
 		testFixturesCompileOnly("org.projectlombok:lombok:${lombokVersion}")
 		testFixturesAnnotationProcessor("org.projectlombok:lombok:${lombokVersion}")

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -15,6 +15,12 @@ testContainerVersion=1.20.0
 testContainerMySqlVersion=1.20.2
 ##rest-assured
 restAssuredVersion=5.5.1
+##awaitilityVersion
+awaitilityVersion=4.2.0
+##web-push
+martijndwarsWebPush=5.1.1
+bouncycastleBcprovJdk18on=1.79
+
 ##node-gradle
 #nodeGradleVersion=7.1.0
 #nodeJsVersion=18.16.0

--- a/backend/live-streaming/interaction/build.gradle.kts
+++ b/backend/live-streaming/interaction/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
 
     implementation(project(":core"))
 
-    testImplementation("org.awaitility:awaitility:4.2.0")
     testImplementation(testFixtures(project(":core")))
     testImplementation(testFixtures(project(":api")))
 

--- a/backend/notification/build.gradle.kts
+++ b/backend/notification/build.gradle.kts
@@ -1,10 +1,15 @@
 val querydslVersion: String by project
+val martijndwarsWebPush: String by project
+val bouncycastleBcprovJdk18on: String by project
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.querydsl:querydsl-jpa:${querydslVersion}:jakarta")
     annotationProcessor("com.querydsl:querydsl-apt:${querydslVersion}:jakarta")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+
+    implementation("nl.martijndwars:web-push:${martijndwarsWebPush}")
+    implementation("org.bouncycastle:bcprov-jdk18on:${bouncycastleBcprovJdk18on}")
 
     implementation(project(":core"))
     implementation(project(":live-streaming:interaction"))

--- a/backend/notification/src/main/java/com/youtube/notification/config/WebPushConfig.java
+++ b/backend/notification/src/main/java/com/youtube/notification/config/WebPushConfig.java
@@ -1,0 +1,27 @@
+package com.youtube.notification.config;
+
+import lombok.RequiredArgsConstructor;
+import nl.martijndwars.webpush.PushAsyncService;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.GeneralSecurityException;
+import java.security.Security;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebPushConfig {
+
+    private final WebPushProperties webPushProperties;
+
+    @Bean
+    public PushAsyncService pushAsyncService() throws GeneralSecurityException {
+        Security.addProvider(new BouncyCastleProvider());
+        return new PushAsyncService(
+                webPushProperties.getPublicKey(),
+                webPushProperties.getPrivateKey(),
+                webPushProperties.getSubject()
+        );
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/config/WebPushProperties.java
+++ b/backend/notification/src/main/java/com/youtube/notification/config/WebPushProperties.java
@@ -1,0 +1,17 @@
+package com.youtube.notification.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "webpush.vapid")
+public class WebPushProperties {
+
+    private String publicKey;
+    private String privateKey;
+    private String subject;
+}

--- a/backend/notification/src/main/java/com/youtube/notification/domain/PushSubscription.java
+++ b/backend/notification/src/main/java/com/youtube/notification/domain/PushSubscription.java
@@ -1,0 +1,92 @@
+package com.youtube.notification.domain;
+
+import com.youtube.core.common.BaseEntity;
+import com.youtube.core.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+/**
+ * Web Push Protocol(RFC 8030, RFC 8291)을 사용한 푸시 알림 구독 정보를 관리하는 엔티티.
+ * 클라이언트(브라우저)가 푸시 알림을 구독할 때 생성되며, 서버가 해당 클라이언트에게
+ * 암호화된 푸시 메시지를 전송하는 데 필요한 정보를 저장합니다.
+ */
+@Entity
+@Table(
+        name = "push_subscription",
+        uniqueConstraints = @UniqueConstraint(columnNames = "endpoint")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PushSubscription extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /**
+     * 푸시 서비스의 고유 엔드포인트 URL.
+     * 서버가 이 URL로 푸시 메시지를 전송하면, 푸시 서비스가 클라이언트에게 전달합니다.
+     * 각 구독마다 고유한 값을 가지며, 구독을 식별하는 데 사용됩니다.
+     */
+    @Column(nullable = false)
+    private String endpoint;
+
+    /**
+     * 클라이언트의 공개키 (P-256 Elliptic Curve Diffie-Hellman Public Key).
+     * Base64로 인코딩된 형태로 저장됩니다.
+     * 서버는 이 공개키를 사용하여 ECDH 키 교환을 통해 공유 비밀을 생성하고,
+     * 이를 기반으로 푸시 메시지를 AES-GCM 대칭 암호화합니다.
+     */
+    @Column(nullable = false)
+    private String p256dh;
+
+    /**
+     * 인증 시크릿 (Authentication Secret).
+     * 클라이언트가 생성한 랜덤 16바이트 값으로, Base64로 인코딩되어 저장됩니다.
+     * p256dh와 함께 사용되어 암호화 키를 파생하고, 메시지의 무결성을 보장합니다.
+     */
+    @Column(nullable = false)
+    private String auth;
+
+    /**
+     * 구독한 클라이언트의 User-Agent 문자열.
+     * 어떤 브라우저/기기에서 구독했는지 추적하고, 디버깅 및 문제 해결에 사용됩니다.
+     * 예: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0"
+     */
+    private String userAgent;
+
+    /**
+     * 해당 구독을 마지막으로 사용한 시간.
+     * 푸시 메시지 전송 성공 시 업데이트되며, 비활성 구독을 식별하는 데 사용됩니다.
+     */
+    private Instant lastUsedDate;
+
+    /**
+     * 구독의 활성화 상태.
+     * 로그인 시 활성화되고, 로그아웃 시 비활성화됩니다.
+     * 알림은 활성화된 구독에만 전송됩니다.
+     */
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean active = true;
+
+    public void updateLastUsedDate() {
+        this.lastUsedDate = Instant.now();
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/domain/PushSubscriptionReader.java
+++ b/backend/notification/src/main/java/com/youtube/notification/domain/PushSubscriptionReader.java
@@ -1,0 +1,27 @@
+package com.youtube.notification.domain;
+
+import com.youtube.notification.repository.PushSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class PushSubscriptionReader {
+
+    private final PushSubscriptionRepository pushSubscriptionRepository;
+
+    public List<PushSubscription> readAllByUserId(final Long userId) {
+        return pushSubscriptionRepository.findAllByUserId(userId);
+    }
+
+    public List<PushSubscription> readAllByUserIdAndActive(final Long userId, final boolean active) {
+        return pushSubscriptionRepository.findAllByUserIdAndActive(userId, active);
+    }
+
+    public Optional<PushSubscription> readByEndpoint(final String endpoint) {
+        return pushSubscriptionRepository.findByEndpoint(endpoint);
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/domain/PushSubscriptionWriter.java
+++ b/backend/notification/src/main/java/com/youtube/notification/domain/PushSubscriptionWriter.java
@@ -1,0 +1,67 @@
+package com.youtube.notification.domain;
+
+import com.youtube.core.user.domain.User;
+import com.youtube.notification.repository.PushSubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PushSubscriptionWriter {
+
+    private final PushSubscriptionRepository pushSubscriptionRepository;
+
+    @Transactional
+    public PushSubscription subscribe(
+            final User user,
+            final String endpoint,
+            final String p256dh,
+            final String auth,
+            final String userAgent
+    ) {
+        final PushSubscription pushSubscription = PushSubscription.builder()
+                .user(user)
+                .endpoint(endpoint)
+                .p256dh(p256dh)
+                .auth(auth)
+                .userAgent(userAgent)
+                .build();
+
+        final PushSubscription saved = pushSubscriptionRepository.save(pushSubscription);
+        log.info("PushSubscription 등록 - userId: {}, endpoint: {}", user.getId(), endpoint);
+        return saved;
+    }
+
+    @Transactional
+    public void unsubscribe(final String endpoint) {
+        pushSubscriptionRepository.deleteByEndpoint(endpoint);
+        log.info("PushSubscription 해지 - endpoint: {}", endpoint);
+    }
+
+    @Transactional
+    public void hardDelete(final Long pushSubscriptionId) {
+        pushSubscriptionRepository.deleteById(pushSubscriptionId);
+        log.info("PushSubscription 삭제 - pushSubscriptionId: {}", pushSubscriptionId);
+    }
+
+    @Transactional
+    public void updateLastUsedDate(final Long pushSubscriptionId) {
+        pushSubscriptionRepository.findById(pushSubscriptionId)
+                .ifPresent(PushSubscription::updateLastUsedDate);
+    }
+
+    @Transactional
+    public void activate(final Long pushSubscriptionId) {
+        pushSubscriptionRepository.findById(pushSubscriptionId)
+                .ifPresent(PushSubscription::activate);
+    }
+
+    @Transactional
+    public void deactivate(final Long pushSubscriptionId) {
+        pushSubscriptionRepository.findById(pushSubscriptionId)
+                .ifPresent(PushSubscription::deactivate);
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/repository/PushSubscriptionRepository.java
+++ b/backend/notification/src/main/java/com/youtube/notification/repository/PushSubscriptionRepository.java
@@ -1,0 +1,18 @@
+package com.youtube.notification.repository;
+
+import com.youtube.notification.domain.PushSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, Long> {
+
+    List<PushSubscription> findAllByUserId(Long userId);
+
+    List<PushSubscription> findAllByUserIdAndActive(Long userId, boolean active);
+
+    Optional<PushSubscription> findByEndpoint(String endpoint);
+
+    void deleteByEndpoint(String endpoint);
+}

--- a/backend/notification/src/main/java/com/youtube/notification/service/PushSubscriptionService.java
+++ b/backend/notification/src/main/java/com/youtube/notification/service/PushSubscriptionService.java
@@ -1,0 +1,66 @@
+package com.youtube.notification.service;
+
+import com.youtube.core.user.domain.User;
+import com.youtube.core.user.domain.UserReader;
+import com.youtube.notification.domain.PushSubscription;
+import com.youtube.notification.domain.PushSubscriptionReader;
+import com.youtube.notification.domain.PushSubscriptionWriter;
+import com.youtube.notification.service.dto.PushSubscribeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PushSubscriptionService {
+
+    private final PushSubscriptionWriter pushSubscriptionWriter;
+    private final PushSubscriptionReader pushSubscriptionReader;
+    private final UserReader userReader;
+
+    @Transactional
+    public void subscribe(final Long userId, final PushSubscribeRequest request) {
+        final User user = userReader.readBy(userId);
+
+        pushSubscriptionReader.readByEndpoint(request.endpoint())
+                .ifPresent(pushSubscription ->
+                        pushSubscriptionWriter.hardDelete(pushSubscription.getId())
+                );
+
+        pushSubscriptionWriter.subscribe(
+                user,
+                request.endpoint(),
+                request.keys().p256dh(),
+                request.keys().auth(),
+                request.userAgent()
+        );
+    }
+
+    @Transactional
+    public void unsubscribe(final String endpoint) {
+        pushSubscriptionReader.readByEndpoint(endpoint)
+                .ifPresent(pushSubscription ->
+                    pushSubscriptionWriter.unsubscribe(endpoint)
+                );
+    }
+
+    @Transactional
+    public void deactivateAllSubscriptions(final Long userId) {
+        final List<PushSubscription> subscriptions = pushSubscriptionReader.readAllByUserId(userId);
+
+        subscriptions.forEach(subscription ->
+                pushSubscriptionWriter.deactivate(subscription.getId())
+        );
+    }
+
+    @Transactional
+    public void reactivateSubscription(final Long userId, final String endpoint) {
+        pushSubscriptionReader.readByEndpoint(endpoint)
+                .filter(subscription -> subscription.getUser().getId().equals(userId))
+                .ifPresent(subscription ->
+                        pushSubscriptionWriter.activate(subscription.getId())
+                );
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/service/WebPushPayloadConverter.java
+++ b/backend/notification/src/main/java/com/youtube/notification/service/WebPushPayloadConverter.java
@@ -1,0 +1,37 @@
+package com.youtube.notification.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.youtube.notification.event.NotificationCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebPushPayloadConverter {
+
+    private final ObjectMapper objectMapper;
+    
+    public String toPayload(final NotificationCreatedEvent event) {
+        try {
+            final Map<String, Object> payload = Map.of(
+                    "notification", Map.of(
+                            "title", event.title(),
+                            "icon", event.thumbnailUrl() != null ? event.thumbnailUrl() : "",
+                            "data", Map.of(
+                                    "url", event.deeplinkUrl(),
+                                    "notificationId", event.notificationId()
+                            )
+                    )
+            );
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            log.error("WebPush 페이로드 생성 실패 - notificationId: {}", event.notificationId(), e);
+            throw new IllegalStateException("WebPush 페이로드 생성 실패", e);
+        }
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/service/WebPushSender.java
+++ b/backend/notification/src/main/java/com/youtube/notification/service/WebPushSender.java
@@ -1,0 +1,37 @@
+package com.youtube.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushAsyncService;
+import nl.martijndwars.webpush.Subscription;
+import org.asynchttpclient.Response;
+import org.jose4j.lang.JoseException;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+@RequiredArgsConstructor
+public class WebPushSender {
+
+    private final PushAsyncService pushAsyncService;
+
+    public CompletableFuture<Response> sendAsync(
+            final String endpoint,
+            final String p256dh,
+            final String auth,
+            final String payload) {
+        try {
+            final Subscription subscription = new Subscription(
+                    endpoint,
+                    new Subscription.Keys(p256dh, auth)
+            );
+
+            return pushAsyncService.send(new Notification(subscription, payload));
+        } catch (GeneralSecurityException | IOException | JoseException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/service/WebPushService.java
+++ b/backend/notification/src/main/java/com/youtube/notification/service/WebPushService.java
@@ -1,0 +1,83 @@
+package com.youtube.notification.service;
+
+import com.youtube.notification.domain.PushSubscription;
+import com.youtube.notification.domain.PushSubscriptionReader;
+import com.youtube.notification.domain.PushSubscriptionWriter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WebPushService {
+
+    private final PushSubscriptionReader pushSubscriptionReader;
+    private final PushSubscriptionWriter pushSubscriptionWriter;
+    private final WebPushSender webPushSender;
+
+    public void sendNotification(final Long userId, final String payload) {
+        final List<PushSubscription> pushSubscriptions =
+                pushSubscriptionReader.readAllByUserIdAndActive(userId, true);
+
+        pushSubscriptions.forEach(pushSubscription -> {
+            webPushSender.sendAsync(
+                    pushSubscription.getEndpoint(),
+                    pushSubscription.getP256dh(),
+                    pushSubscription.getAuth(),
+                    payload
+            )
+            .thenAccept(response -> handleResponse(response, pushSubscription, userId))
+            .exceptionally(throwable -> {
+                handleNetworkFailure(pushSubscription, userId, throwable);
+                return null;
+            });
+        });
+    }
+
+    /**
+     * WebPush 응답 처리
+     *
+     * "It checks for status codes 404 and 410, which are the HTTP status codes for 'Not Found' and 'Gone'.
+     * If we receive one of these, it means the subscription has expired or is no longer valid.
+     * In these scenarios, we need to remove the subscriptions from our database."
+     *
+     * Reference: https://web.dev/articles/sending-messages-with-web-push-libraries
+     */
+    private void handleResponse(final org.asynchttpclient.Response response, final PushSubscription pushSubscription, final Long userId) {
+        final int statusCode = response.getStatusCode();
+
+        if (shouldDeleteSubscription(statusCode)) {
+            pushSubscriptionWriter.hardDelete(pushSubscription.getId());
+            log.info("구독 만료로 삭제 - userId: {}, statusCode: {}, endpoint: {}",
+                    userId, statusCode, pushSubscription.getEndpoint());
+        } else if (statusCode >= 200 && statusCode < 300) {
+            handleSuccess(pushSubscription, userId);
+        } else {
+            log.warn("WebPush 전송 실패 - userId: {}, statusCode: {}, endpoint: {}",
+                    userId, statusCode, pushSubscription.getEndpoint());
+        }
+    }
+
+    private void handleSuccess(final PushSubscription pushSubscription, final Long userId) {
+        pushSubscriptionWriter.updateLastUsedDate(pushSubscription.getId());
+
+        log.info("WebPush 전송 성공 - userId: {}, pushSubscriptionId: {}, endpoint: {}",
+                userId, pushSubscription.getId(), pushSubscription.getEndpoint());
+    }
+
+    /**
+     * 410 Gone: 구독이 영구적으로 만료됨
+     * 404 Not Found: 구독 엔드포인트가 존재하지 않음
+     */
+    private boolean shouldDeleteSubscription(final int statusCode) {
+        return statusCode == 404 || statusCode == 410;
+    }
+
+    private void handleNetworkFailure(final PushSubscription pushSubscription, final Long userId, final Throwable throwable) {
+        log.error("WebPush 네트워크 오류 - userId: {}, endpoint: {}, error: {}",
+                userId, pushSubscription.getEndpoint(), throwable.getMessage(), throwable);
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/service/dto/PushSubscribeRequest.java
+++ b/backend/notification/src/main/java/com/youtube/notification/service/dto/PushSubscribeRequest.java
@@ -1,0 +1,7 @@
+package com.youtube.notification.service.dto;
+
+public record PushSubscribeRequest(String endpoint, Keys keys, String userAgent) {
+
+    public record Keys(String p256dh, String auth) {
+    }
+}

--- a/backend/notification/src/main/java/com/youtube/notification/service/dto/PushUnsubscribeRequest.java
+++ b/backend/notification/src/main/java/com/youtube/notification/service/dto/PushUnsubscribeRequest.java
@@ -1,0 +1,6 @@
+package com.youtube.notification.service.dto;
+
+public record PushUnsubscribeRequest(
+        String endpoint
+) {
+}

--- a/backend/notification/src/test/java/com/youtube/notification/domain/PushSubscriptionWriterTest.java
+++ b/backend/notification/src/test/java/com/youtube/notification/domain/PushSubscriptionWriterTest.java
@@ -1,0 +1,41 @@
+package com.youtube.notification.domain;
+
+import com.youtube.core.user.domain.User;
+import com.youtube.notification.config.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.youtube.core.testfixtures.builder.UserBuilder.User;
+import static com.youtube.notification.testfixtures.builder.PushSubscriptionBuilder.PushSubscription;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PushSubscriptionWriterTest extends IntegrationTest {
+
+    @Autowired
+    private PushSubscriptionWriter sut;
+
+    @Test
+    @DisplayName("존재하는 구독을 삭제하면 DB에서 삭제된다")
+    void hardDelete_ExistingSubscription_DeleteFromDatabase() {
+        // given
+        final User user = testSupport.save(User().build());
+        final PushSubscription subscription = testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .build()
+        );
+        final Long subscriptionId = subscription.getId();
+
+        // when
+        sut.hardDelete(subscriptionId);
+
+        // then
+        final PushSubscription deletedSubscription = testSupport.jpaQueryFactory
+                .selectFrom(QPushSubscription.pushSubscription)
+                .where(QPushSubscription.pushSubscription.id.eq(subscriptionId))
+                .fetchOne();
+
+        assertThat(deletedSubscription).isNull();
+    }
+}

--- a/backend/notification/src/test/java/com/youtube/notification/service/WebPushSenderTest.java
+++ b/backend/notification/src/test/java/com/youtube/notification/service/WebPushSenderTest.java
@@ -1,0 +1,81 @@
+package com.youtube.notification.service;
+
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushAsyncService;
+import org.asynchttpclient.Response;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Security;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WebPushSenderTest {
+
+    private WebPushSender sut;
+
+    @Mock
+    private PushAsyncService pushAsyncService;
+
+    @BeforeAll
+    static void setUpClass() {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    @BeforeEach
+    void setUp() {
+        sut = new WebPushSender(pushAsyncService);
+    }
+
+    @Test
+    @DisplayName("유효한 구독 정보와 페이로드로 푸시를 전송하면 성공한다")
+    void sendAsync_ValidSubscription_Success() throws Exception {
+        // given
+        final String endpoint = "https://fcm.googleapis.com/fcm/send/test-endpoint";
+        final String p256dh = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM=";
+        final String auth = "tBHItJI5svbpez7KI4CCXg==";
+        final String payload = "{\"title\":\"Test Notification\"}";
+
+        final Response mockResponse = mock(Response.class);
+        when(mockResponse.getStatusCode()).thenReturn(201);
+        when(pushAsyncService.send(any(Notification.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+        // when
+        final CompletableFuture<Response> result = sut.sendAsync(endpoint, p256dh, auth, payload);
+
+        // then
+        assertThat(result).isCompleted();
+        assertThat(result.get().getStatusCode()).isEqualTo(201);
+        verify(pushAsyncService, times(1)).send(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("PushAsyncService에서 예외가 발생하면 실패한 CompletableFuture를 반환한다")
+    void sendAsync_ServiceThrowsException_ReturnFailedFuture() throws Exception {
+        // given
+        final String endpoint = "https://fcm.googleapis.com/fcm/send/test-endpoint";
+        final String p256dh = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM=";
+        final String auth = "tBHItJI5svbpez7KI4CCXg==";
+        final String payload = "{\"title\":\"Test Notification\"}";
+
+        when(pushAsyncService.send(any(Notification.class)))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Push service error")));
+
+        // when
+        final CompletableFuture<Response> result = sut.sendAsync(endpoint, p256dh, auth, payload);
+
+        // then
+        assertThat(result).isCompletedExceptionally();
+    }
+}

--- a/backend/notification/src/test/java/com/youtube/notification/service/WebPushServiceTest.java
+++ b/backend/notification/src/test/java/com/youtube/notification/service/WebPushServiceTest.java
@@ -1,0 +1,204 @@
+package com.youtube.notification.service;
+
+import com.youtube.core.user.domain.User;
+import com.youtube.notification.config.IntegrationTest;
+import com.youtube.notification.domain.PushSubscription;
+import com.youtube.notification.domain.QPushSubscription;
+import org.asynchttpclient.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import static com.youtube.core.testfixtures.builder.UserBuilder.User;
+import static com.youtube.notification.testfixtures.builder.PushSubscriptionBuilder.PushSubscription;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class WebPushServiceTest extends IntegrationTest {
+
+    @Autowired
+    private WebPushService sut;
+
+    @MockitoBean
+    private WebPushSender webPushSender;
+
+    @Test
+    @DisplayName("활성 상태의 구독에만 푸시 알림이 전송된다")
+    void sendNotification_OnlyActiveSubscriptions_SendPush() {
+        // given
+        final User user = testSupport.save(User().build());
+        final PushSubscription activeSubscription = testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withEndpoint("active-endpoint")
+                        .withActive(true)
+                        .build()
+        );
+        testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withEndpoint("inactive-endpoint")
+                        .withActive(false)
+                        .build()
+        );
+
+        final Response mockResponse = mock(Response.class);
+        when(mockResponse.getStatusCode()).thenReturn(201);
+        when(webPushSender.sendAsync(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+        // when
+        sut.sendNotification(user.getId(), "{\"title\":\"Test\"}");
+
+        // then
+        verify(webPushSender, times(1))
+                .sendAsync(
+                        eq(activeSubscription.getEndpoint()),
+                        eq(activeSubscription.getP256dh()),
+                        eq(activeSubscription.getAuth()),
+                        eq("{\"title\":\"Test\"}")
+                );
+    }
+
+    @Test
+    @DisplayName("410 Gone 응답 시 구독이 삭제된다")
+    void sendNotification_410Gone_DeleteSubscription() {
+        // given
+        final User user = testSupport.save(User().build());
+        final PushSubscription subscription = testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withActive(true)
+                        .build()
+        );
+
+        final Response mockResponse = mock(Response.class);
+        when(mockResponse.getStatusCode()).thenReturn(410);
+        when(webPushSender.sendAsync(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+        // when
+        sut.sendNotification(user.getId(), "{\"title\":\"Test\"}");
+
+        // then
+        await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    final PushSubscription foundSubscription = testSupport.jpaQueryFactory
+                            .selectFrom(QPushSubscription.pushSubscription)
+                            .where(QPushSubscription.pushSubscription.id.eq(subscription.getId()))
+                            .fetchOne();
+
+                    assertThat(foundSubscription).isNull();
+                });
+    }
+
+    @Test
+    @DisplayName("404 Not Found 응답 시 구독이 삭제된다")
+    void sendNotification_404NotFound_DeleteSubscription() {
+        // given
+        final User user = testSupport.save(User().build());
+        final PushSubscription subscription = testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withActive(true)
+                        .build()
+        );
+
+        final Response mockResponse = mock(Response.class);
+        when(mockResponse.getStatusCode()).thenReturn(404);
+        when(webPushSender.sendAsync(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+        // when
+        sut.sendNotification(user.getId(), "{\"title\":\"Test\"}");
+
+        // then
+        await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    final PushSubscription foundSubscription = testSupport.jpaQueryFactory
+                            .selectFrom(QPushSubscription.pushSubscription)
+                            .where(QPushSubscription.pushSubscription.id.eq(subscription.getId()))
+                            .fetchOne();
+
+                    assertThat(foundSubscription).isNull();
+                });
+    }
+
+    @Test
+    @DisplayName("410, 404 외의 오류 발생 시 구독이 삭제되지 않는다")
+    void sendNotification_OtherError_SubscriptionNotDeleted() {
+        // given
+        final User user = testSupport.save(User().build());
+        final PushSubscription subscription = testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withActive(true)
+                        .build()
+        );
+
+        when(webPushSender.sendAsync(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.failedFuture(
+                        new RuntimeException("Network error")
+                ));
+
+        // when
+        sut.sendNotification(user.getId(), "{\"title\":\"Test\"}");
+
+        // then
+        await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    final PushSubscription existingSubscription = testSupport.jpaQueryFactory
+                            .selectFrom(QPushSubscription.pushSubscription)
+                            .where(QPushSubscription.pushSubscription.id.eq(subscription.getId()))
+                            .fetchOne();
+
+                    assertThat(existingSubscription).isNotNull();
+                });
+    }
+
+    @Test
+    @DisplayName("사용자가 여러 구독을 가지고 있으면 모든 활성 구독에 푸시를 전송한다")
+    void sendNotification_MultipleActiveSubscriptions_SendToAll() {
+        // given
+        final User user = testSupport.save(User().build());
+        final PushSubscription subscription1 = testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withEndpoint("endpoint-1")
+                        .withActive(true)
+                        .build()
+        );
+        final PushSubscription subscription2 = testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withEndpoint("endpoint-2")
+                        .withActive(true)
+                        .build()
+        );
+        final PushSubscription subscription3 = testSupport.save(
+                PushSubscription()
+                        .withUser(user)
+                        .withEndpoint("endpoint-3")
+                        .withActive(true)
+                        .build()
+        );
+
+        final Response mockResponse = mock(Response.class);
+        when(mockResponse.getStatusCode()).thenReturn(201);
+        when(webPushSender.sendAsync(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+        // when
+        sut.sendNotification(user.getId(), "{\"title\":\"Test\"}");
+
+        // then
+        verify(webPushSender, times(3))
+                .sendAsync(anyString(), anyString(), anyString(), eq("{\"title\":\"Test\"}"));
+    }
+}

--- a/backend/notification/src/testFixtures/java/com/youtube/notification/testfixtures/builder/PushSubscriptionBuilder.java
+++ b/backend/notification/src/testFixtures/java/com/youtube/notification/testfixtures/builder/PushSubscriptionBuilder.java
@@ -1,0 +1,42 @@
+package com.youtube.notification.testfixtures.builder;
+
+import com.youtube.core.user.domain.User;
+import com.youtube.notification.domain.PushSubscription;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.With;
+
+import java.time.Instant;
+
+@With
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PushSubscriptionBuilder {
+
+    private Long id;
+    private User user;
+    private String endpoint = "https://fcm.googleapis.com/fcm/send/test-endpoint";
+    private String p256dh = "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpQtUbVlUls0VJXg7A8u-Ts1XbjhazAkj7I99e8QcYP7DkM=";
+    private String auth = "tBHItJI5svbpez7KI4CCXg==";
+    private String userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0";
+    private Instant lastUsedDate;
+    private boolean active = true;
+
+    public static PushSubscriptionBuilder PushSubscription() {
+        return new PushSubscriptionBuilder();
+    }
+
+    public PushSubscription build() {
+        return PushSubscription.builder()
+                .id(this.id)
+                .user(this.user)
+                .endpoint(this.endpoint)
+                .p256dh(this.p256dh)
+                .auth(this.auth)
+                .userAgent(this.userAgent)
+                .lastUsedDate(this.lastUsedDate)
+                .active(this.active)
+                .build();
+    }
+}


### PR DESCRIPTION
 1. 알림 생성
  - 라이브 스트리밍 시작 시 구독자에게 알림 생성
  - 이벤트 기반 비동기 처리 (LiveStreamingStartedEvent →
  NotificationCreatedEvent)

  2. 알림 푸시
  - SSE 연결 상태: SSE를 통해 실시간 푸시
  - SSE 미연결 상태: Web Push Protocol로 푸시
  - 활성화된 구독에만 전송

  3. 알림 조회 및 읽음 처리
  - 최근 35일 이내 알림 조회 (커서 기반 페이지네이션)
  - 모든 알림 읽음 처리
  - 실시간 미읽음 개수 SSE 푸시

  4. Web Push 구독 관리
  - 구독/해제 API
  - 로그아웃 시 모든 구독 비활성화
  - 로그인 시 구독 재활성화
  - 만료된 구독 자동 삭제 (410 Gone, 404 Not Found 응답 처리)
  